### PR TITLE
Force reschedule after IRQ

### DIFF
--- a/rp2040.c
+++ b/rp2040.c
@@ -97,6 +97,7 @@ void rp2040_intr_handler(void* arg) {
     /* in interrupt handler context */
     RP2040* device = (RP2040*) arg;
     xSemaphoreGiveFromISR(device->_intr_trigger, NULL);
+    portYIELD_FROM_ISR();
 }
 
 esp_err_t rp2040_init(RP2040* device) {


### PR DESCRIPTION
This way the blocked task gets unblocked ASAP rather than
waiting for the next tick.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>