### PR TITLE
[WIP] rp2040bl: add CRC and READ command wrappers

### DIFF
--- a/include/rp2040bl.h
+++ b/include/rp2040bl.h
@@ -10,6 +10,8 @@ void rp2040_bl_uninstall_uart();
 bool rp2040_bl_sync();
 bool rp2040_bl_get_info(uint32_t* flash_start, uint32_t* flash_size, uint32_t* erase_size, uint32_t* write_size, uint32_t* max_data_len);
 bool rp2040_bl_erase(uint32_t address, uint32_t length);
+bool rp2040_bl_crc(uint32_t address, uint32_t length, uint32_t* crc);
+bool rp2040_bl_read(uint32_t address, uint32_t length, uint8_t* data);
 bool rp2040_bl_write(uint32_t address, uint32_t length, uint8_t* data, uint32_t* crc);
 bool rp2040_bl_seal(uint32_t vtor, uint32_t length, uint32_t crc);
 bool rp2040_bl_go(uint32_t vtor);

--- a/rp2040bl.c
+++ b/rp2040bl.c
@@ -85,6 +85,36 @@ bool rp2040_bl_erase(uint32_t address, uint32_t length) {
     return true;
 }
 
+bool rp2040_bl_crc(uint32_t address, uint32_t length, uint32_t* crc) {
+    if (!uart_is_driver_installed(RP2040_BL_UART)) return false;
+    flush_stdin();
+    char command[12];
+    snprintf(command, 5, "CRCC");
+    memcpy(command + 4, (char*) &address, 4);
+    memcpy(command + 4, (char*) &length, 4);
+    uart_write_bytes(RP2040_BL_UART, command, sizeof (command));
+    uint8_t rx_buffer[8];
+    read_stdin(rx_buffer, sizeof(rx_buffer), 10000);
+    if (memcmp(rx_buffer, "OKOK", 4) != 0) return false;
+    memcpy((uint8_t*) crc, &rx_buffer[4 * 1], 4);
+    return true;
+}
+
+bool rp2040_bl_read(uint32_t address, uint32_t length, uint8_t* data) {
+    if (!uart_is_driver_installed(RP2040_BL_UART)) return false;
+    flush_stdin();
+    char command[12];
+    snprintf(command, 5, "READ");
+    memcpy(command + 4, (char*) &address, 4);
+    memcpy(command + 4, (char*) &length, 4);
+    uart_write_bytes(RP2040_BL_UART, command, sizeof (command));
+    uint8_t rx_buffer[4];
+    read_stdin(rx_buffer, 4, 10000);
+    read_stdin(data, length, 10000);
+    if (memcmp(rx_buffer, "OKOK", 4) != 0) return false;
+    return true;
+}
+
 bool rp2040_bl_write(uint32_t address, uint32_t length, uint8_t* data, uint32_t* crc) {
     if (!uart_is_driver_installed(RP2040_BL_UART)) return false;
     flush_stdin();


### PR DESCRIPTION
This PR adds wrappers for the CRC and READ rp2040 bootloader commands.
This PR is WIP and not yet tested, but PR already created to reduce duplicate efforts.

This feature is intended to be used by ESP32 applications wanting to install custom RP2040 firmware to reduce unnecessary reflashing of custom firmware if it hasn't changed.