### PR TITLE
rp2040bl: fix CRC and READ commands

### DIFF
--- a/rp2040bl.c
+++ b/rp2040bl.c
@@ -91,8 +91,8 @@ bool rp2040_bl_crc(uint32_t address, uint32_t length, uint32_t* crc) {
     char command[12];
     snprintf(command, 5, "CRCC");
     memcpy(command + 4, (char*) &address, 4);
-    memcpy(command + 4, (char*) &length, 4);
-    uart_write_bytes(RP2040_BL_UART, command, sizeof (command));
+    memcpy(command + 8, (char*) &length, 4);
+    uart_write_bytes(RP2040_BL_UART, command, sizeof(command));
     uint8_t rx_buffer[8];
     read_stdin(rx_buffer, sizeof(rx_buffer), 10000);
     if (memcmp(rx_buffer, "OKOK", 4) != 0) return false;
@@ -106,10 +106,10 @@ bool rp2040_bl_read(uint32_t address, uint32_t length, uint8_t* data) {
     char command[12];
     snprintf(command, 5, "READ");
     memcpy(command + 4, (char*) &address, 4);
-    memcpy(command + 4, (char*) &length, 4);
+    memcpy(command + 8, (char*) &length, 4);
     uart_write_bytes(RP2040_BL_UART, command, sizeof (command));
     uint8_t rx_buffer[4];
-    read_stdin(rx_buffer, 4, 10000);
+    read_stdin(rx_buffer, sizeof(rx_buffer), 10000);
     read_stdin(data, length, 10000);
     if (memcmp(rx_buffer, "OKOK", 4) != 0) return false;
     return true;


### PR DESCRIPTION
This PR fixes two typos in the CRC and READ commands that made them not work at all. (oops)